### PR TITLE
docs: improve --help, humanize README, agent usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
-# 🚨 ICF — Incident Command Framework
+# icf — Incident Command Framework
 
-CLI-first incident management backed by GitHub. Designed for AI agents and DevOps teams.
+Manage service incidents through GitHub Issues from your terminal. No third-party tools. No vendor lock-in. Just your existing GitHub org, structured labels, and automated triage workflows.
+
+## What it does
+
+icf turns a GitHub repository into a full incident management system:
+
+- Every incident is a GitHub issue with severity labels, status tracking, and a comment timeline
+- `icf init` sets up labels, issue templates, and GitHub Actions workflows in one command  
+- `icf incident create` opens an incident in seconds, with or without a TTY
+- AI agents can use `--input-json` and `--json` for fully programmatic operation
+
+## The CLI lives in `cli/`
+
+```
+icf/
+├── cli/              ← npm package (@blackasteroid/icf)
+│   ├── src/
+│   │   ├── commands/ ← auth, init, incident, config, upgrade
+│   │   ├── utils/    ← format, box, errors
+│   │   ├── config.ts ← local config (~/.config/icf-nodejs/)
+│   │   ├── github.ts ← Octokit wrapper + ICF labels
+│   │   └── index.ts  ← CLI entry point
+│   └── dist/         ← compiled binary
+├── .github/
+│   └── workflows/    ← incident-triage.yml, incident-escalation.yml
+└── README.md
+```
 
 ## Install
 
@@ -8,95 +34,29 @@ CLI-first incident management backed by GitHub. Designed for AI agents and DevOp
 npm install -g @blackasteroid/icf
 ```
 
-## Quick Start
+## Quick start
 
 ```bash
-# 1. Authenticate
 icf auth login
-
-# 2. Bootstrap an incident repo
-icf init BlackAsteroid/incidents
-
-# 3. Create an incident
-icf incident create --severity P1 --service api-gateway --description "Latency spike"
-
-# 4. Update status
-icf incident update INC-1 --status investigating
-
-# 5. Add timeline events
-icf incident timeline INC-1 --event "Found db connection pool exhaustion"
-
-# 6. Resolve
-icf incident resolve INC-1 --root-cause "Increased pool size, deployed fix"
+icf init my-org/incidents --create
+icf incident create --severity P1 --service api --title "Latency spike" --description "..."
+icf incident list
+icf incident resolve INC-001 --rca "Root cause fixed"
 ```
 
-## Commands
+Full documentation: [cli/README.md](./cli/README.md)
 
-### `icf auth`
-```
-icf auth login [--token '$GITHUB_TOKEN']
-icf auth logout
-icf auth status
-```
-
-### `icf init <org/repo>`
-Bootstraps a GitHub repo with ICF labels, issue templates, and configuration.
-
-### `icf incident`
-```
-icf incident create --severity <P0-P3> --service <name> --description <text>
-icf incident list [--severity P1] [--status investigating] [--service api]
-icf incident show INC-42
-icf incident update INC-42 --status mitigating
-icf incident resolve INC-42 --root-cause "..."
-icf incident timeline INC-42 --event "Deployed hotfix"
-```
-
-### `icf config`
-```
-icf config validate
-icf config show
-```
-
-## JSON Mode
-
-All commands support `--json` for machine-readable output:
+## Agent usage
 
 ```bash
+# Create an incident from a JSON payload
+echo '{"title":"DB down","service":"postgres","severity":"P0","description":"..."}' \
+  | icf incident create --input-json --json
+
+# Get structured output
 icf incident list --json | jq '.data[] | select(.severity == "P0")'
-ICF_JSON=1 icf incident create --severity P1 --service api --description "..."
 ```
-
-## Agent Workflow
-
-```bash
-# Full lifecycle
-INCIDENT=$(icf incident create --severity P1 --service api --description "Spike" --json | jq -r '.data.incident_id')
-icf incident update $INCIDENT --status investigating
-icf incident timeline $INCIDENT --event "Root cause identified"
-icf incident resolve $INCIDENT --root-cause "Fixed and deployed"
-```
-
-## Severity Levels
-
-| Level | Description |
-|-------|-------------|
-| P0 | Critical — full outage or data loss |
-| P1 | High — major feature degradation |
-| P2 | Medium — partial degradation |
-| P3 | Low — minor issue |
-
-## Exit Codes
-
-| Code | Meaning |
-|------|---------|
-| 0 | Success |
-| 1 | General error |
-| 2 | Network error |
-| 3 | Not found |
-| 4 | Auth error |
-| 5 | Validation error |
 
 ## License
 
-MIT — Black Asteroid
+MIT — [Black Asteroid](https://blackasteroid.com.ar)

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
-# 🚨 ICF — Incident Command Framework
+# icf — Incident Command Framework
 
-CLI-first incident management backed by GitHub. Designed for AI agents and DevOps teams.
+Manage service incidents through GitHub Issues from your terminal. Every incident is a GitHub issue with structured labels and a timeline of comments — no third-party tools, no vendor lock-in, and a full audit trail in your existing GitHub org.
 
 ## Install
 
@@ -8,85 +8,157 @@ CLI-first incident management backed by GitHub. Designed for AI agents and DevOp
 npm install -g @blackasteroid/icf
 ```
 
-## Quick Start
+Or try it without installing:
+
+```bash
+npx @blackasteroid/icf auth login
+```
+
+## Quick start
 
 ```bash
 # 1. Authenticate
 icf auth login
 
-# 2. Bootstrap an incident repo
-icf init BlackAsteroid/incidents
+# 2. Set up your incident repo (creates labels, templates, workflows)
+icf init my-org/incidents --create
 
-# 3. Create an incident
-icf incident create --severity P1 --service api-gateway --description "Latency spike"
+# 3. Open an incident
+icf incident create \
+  --severity P1 \
+  --service api-gateway \
+  --title "High latency on checkout" \
+  --description "p99 > 3s since 14:20 UTC"
 
-# 4. Update status
-icf incident update INC-1 --status investigating
+# 4. Add a timeline entry
+icf incident comment INC-001 --message "Identified db query regression"
 
-# 5. Add timeline events
-icf incident timeline INC-1 --event "Found db connection pool exhaustion"
+# 5. Mark as mitigating
+icf incident mitigate INC-001 --message "Rolling back to v1.4.2"
 
-# 6. Resolve
-icf incident resolve INC-1 --root-cause "Increased pool size, deployed fix"
+# 6. Resolve with root cause
+icf incident resolve INC-001 --rca "Unindexed query introduced in v1.4.3, rolled back"
 ```
 
 ## Commands
 
 ### `icf auth`
-```
-icf auth login [--token '$GITHUB_TOKEN']
-icf auth logout
+
+```bash
+icf auth login                    # Prompted for a GitHub token
+icf auth login --token '$TOKEN'   # Token from env var (recommended in scripts)
 icf auth status
+icf auth logout
 ```
 
-### `icf init <org/repo>`
-Bootstraps a GitHub repo with ICF labels, issue templates, and configuration.
+Token needs these scopes: `repo`, `workflow`, `write:packages`.  
+Create one at: [github.com/settings/tokens/new?scopes=repo,workflow,write:packages&description=icf-cli](https://github.com/settings/tokens/new?scopes=repo,workflow,write:packages&description=icf-cli)
+
+### `icf init <owner/repo>`
+
+Sets up a GitHub repo for incident tracking. Creates severity and status labels, an issue template, a milestone, and two GitHub Actions workflows (triage and escalation).
+
+```bash
+icf init my-org/incidents              # Configure an existing repo
+icf init my-org/incidents --create     # Create the repo first, then configure
+icf init my-org/incidents --create --public
+icf init my-org/incidents --no-workflows   # Skip pushing GitHub Actions
+```
 
 ### `icf incident`
-```
-icf incident create --severity <P0-P3> --service <name> --description <text>
-icf incident list [--severity P1] [--status investigating] [--service api]
-icf incident show INC-42
-icf incident update INC-42 --status mitigating
-icf incident resolve INC-42 --root-cause "..."
-icf incident timeline INC-42 --event "Deployed hotfix"
+
+```bash
+# Open an incident
+icf incident create --severity P0 --service payments --title "DB unreachable" --description "..."
+
+# List
+icf incident list                       # Open incidents
+icf incident list --severity P0         # Filter by severity
+icf incident list --status mitigating   # Filter by status
+icf incident list --all                 # Include resolved
+
+# View
+icf incident show INC-001
+
+# Update severity or service
+icf incident update INC-001 --severity P1
+icf incident update INC-001 --service auth-svc --severity P2
+
+# Add a timeline entry
+icf incident comment INC-001 --message "Deployed hotfix, monitoring"
+icf incident comment INC-001 -m "Rollback complete"
+echo "Status update" | icf incident comment INC-001
+
+# Mark as mitigating
+icf incident mitigate INC-001
+icf incident mitigate INC-001 --message "Fix deployed, watching metrics"
+
+# Resolve
+icf incident resolve INC-001 --rca "Root cause description"
+icf incident resolve INC-001 --rca-file ./rca.md
 ```
 
 ### `icf config`
-```
-icf config validate
+
+```bash
 icf config show
+icf config validate
+icf config validate --repo my-org/incidents
 ```
 
-## JSON Mode
-
-All commands support `--json` for machine-readable output:
+### `icf upgrade`
 
 ```bash
-icf incident list --json | jq '.data[] | select(.severity == "P0")'
-ICF_JSON=1 icf incident create --severity P1 --service api --description "..."
+icf upgrade           # Update to latest published version
+icf upgrade --json
 ```
 
-## Agent Workflow
+## Severity levels
 
-```bash
-# Full lifecycle
-INCIDENT=$(icf incident create --severity P1 --service api --description "Spike" --json | jq -r '.data.incident_id')
-icf incident update $INCIDENT --status investigating
-icf incident timeline $INCIDENT --event "Root cause identified"
-icf incident resolve $INCIDENT --root-cause "Fixed and deployed"
-```
-
-## Severity Levels
-
-| Level | Description |
-|-------|-------------|
+| Level | Meaning |
+|-------|---------|
 | P0 | Critical — full outage or data loss |
-| P1 | High — major feature degradation |
+| P1 | High — major feature broken |
 | P2 | Medium — partial degradation |
 | P3 | Low — minor issue |
 
-## Exit Codes
+## Incident lifecycle
+
+`open` → `mitigating` → `resolved`
+
+Each transition posts a timeline comment. Resolved incidents are closed as GitHub issues.
+
+---
+
+## Using icf as an agent
+
+icf is designed to be operated by AI agents. Every command produces machine-readable output and accepts structured input.
+
+### JSON output mode
+
+Add `--json` to any command, or set `ICF_JSON=1` globally:
+
+```bash
+# Single command
+icf incident list --json
+
+# All commands for this session
+ICF_JSON=1 icf incident create --severity P1 --service api --title "Down"
+```
+
+### Response envelope
+
+All responses follow the same shape:
+
+```json
+// Success
+{ "ok": true, "data": { ... } }
+
+// Error
+{ "ok": false, "error": "Incident INC-999 not found", "code": 3 }
+```
+
+### Exit codes
 
 | Code | Meaning |
 |------|---------|
@@ -97,6 +169,60 @@ icf incident resolve $INCIDENT --root-cause "Fixed and deployed"
 | 4 | Auth error |
 | 5 | Validation error |
 
+### Creating incidents from a JSON payload
+
+Agents can pipe a JSON object directly to `incident create`:
+
+```bash
+# Inline flag
+icf incident create \
+  --input-json '{"title":"DB latency","service":"postgres","severity":"P1","description":"p99 > 5s"}' \
+  --json
+
+# Stdin pipe
+echo '{"title":"DB latency","service":"postgres","severity":"P1","description":"p99 > 5s"}' \
+  | icf incident create --input-json --json
+
+# From a file
+cat incident-payload.json | icf incident create --input-json --json
+```
+
+Required fields in the payload: `title`, `severity`. Optional: `service`, `description`, `assign`.
+
+### Full agent pipeline
+
+```bash
+# 1. Create
+INC=$(icf incident create \
+  --severity P1 --service api --title "Latency spike" --description "p99 > 3s" \
+  --json | jq -r '.data.id')
+
+# 2. Add investigation notes
+icf incident comment $INC --message "Traced to db query regression" --json
+
+# 3. Mark as mitigating
+icf incident mitigate $INC --message "Rollback initiated" --json
+
+# 4. Resolve
+icf incident resolve $INC --rca "Rolled back v1.4.3, issue fixed" --json
+```
+
+### Version check
+
+```bash
+icf version --json
+# → { "ok": true, "data": { "version": "1.1.0", "name": "@blackasteroid/icf" } }
+
+icf --version --json
+# → same
+```
+
+---
+
+## Security
+
+Report vulnerabilities privately to **security@blackasteroid.com.ar**. See [SECURITY.md](./SECURITY.md).
+
 ## License
 
-MIT — Black Asteroid
+MIT — [Black Asteroid](https://blackasteroid.com.ar)

--- a/cli/src/commands/auth.ts
+++ b/cli/src/commands/auth.ts
@@ -9,12 +9,22 @@ import { handleError, EXIT } from "../utils/errors.js";
 const { prompt } = enquirer as any;
 
 export function authCommand(program: Command): void {
-  const auth = program.command("auth").description("Manage GitHub authentication");
+  const auth = program
+    .command("auth")
+    .description("Authenticate with GitHub using a personal access token")
+    .addHelpText("after", `
+${chalk.dim("Subcommands:")}
+  ${chalk.cyan("auth login")}    Store a GitHub token
+  ${chalk.cyan("auth status")}   Show who you're logged in as
+  ${chalk.cyan("auth logout")}   Remove stored credentials
+
+${chalk.dim("Run")} ${chalk.cyan("icf auth <subcommand> --help")} ${chalk.dim("for examples.")}
+`);
 
   // LOGIN
   auth
     .command("login")
-    .description("Authenticate with GitHub using a personal access token")
+    .description("Store a GitHub token and verify it has the right scopes")
     .option("--token <token|$VAR>", "GitHub PAT or env var reference like '$GITHUB_TOKEN'")
     .option("--json", "Output as JSON")
     .addHelpText("after", `

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -6,7 +6,14 @@ import { success, errorLine, isJsonMode, jsonOut } from "../utils/format.js";
 import { handleError } from "../utils/errors.js";
 
 export function configCommand(program: Command): void {
-  const cfg = program.command("config").description("Manage ICF configuration");
+  const cfg = program
+    .command("config")
+    .description("Show and validate your ICF configuration")
+    .addHelpText("after", `
+${chalk.dim("Subcommands:")}
+  ${chalk.cyan("config validate")}   Check that auth and repo are working
+  ${chalk.cyan("config show")}       Print current auth user and target repo
+`);
 
   cfg
     .command("validate")

--- a/cli/src/commands/incident.ts
+++ b/cli/src/commands/incident.ts
@@ -32,16 +32,19 @@ const VALID_STATUSES   = ["open", "mitigating", "resolved"];
 export function incidentCommand(program: Command): void {
   const inc = program
     .command("incident")
-    .description("Manage incidents — create, list, show, update, resolve")
+    .description("Open, track, and resolve service incidents")
     .addHelpText("after", `
-${chalk.dim("Commands:")}
-  ${chalk.cyan("incident create")}          Open a new incident
-  ${chalk.cyan("incident list")}            List open incidents
-  ${chalk.cyan("incident show <id>")}       Show full incident details
-  ${chalk.cyan("incident update <id>")}     Change severity, service, or title
-  ${chalk.cyan("incident mitigate <id>")}   Transition to mitigating status
-  ${chalk.cyan("incident comment <id>")}    Add a timeline entry
-  ${chalk.cyan("incident resolve <id>")}    Close the incident with RCA
+${chalk.dim("Subcommands:")}
+  ${chalk.cyan("incident create")}            Open a new incident
+  ${chalk.cyan("incident list")}              List open incidents
+  ${chalk.cyan("incident show <id>")}         Show full details and timeline
+  ${chalk.cyan("incident update <id>")}       Change severity, service, or title
+  ${chalk.cyan("incident mitigate <id>")}     Mark as being actively mitigated
+  ${chalk.cyan("incident comment <id>")}      Add a timestamped timeline entry
+  ${chalk.cyan("incident resolve <id>")}      Close the incident and record the root cause
+
+${chalk.dim("IDs are")} ${chalk.cyan("INC-001")} ${chalk.dim("format (matching the GitHub issue number).")}
+${chalk.dim("Run")} ${chalk.cyan("icf incident <subcommand> --help")} ${chalk.dim("for examples.")}
 `);
 
   // ── CREATE ──────────────────────────────────────────────────────────────────

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -177,7 +177,7 @@ jobs:
 export function initCommand(program: Command): void {
   program
     .command("init [owner/repo]")
-    .description("Bootstrap a GitHub repo as a fully configured ICF incident repository")
+    .description("Set up a GitHub repo for ICF incident tracking (labels, templates, workflows)")
     .option("--create",        "Create the repository if it does not exist")
     .option("--private",       "When --create: make the repo private (default)")
     .option("--public",        "When --create: make the repo public")

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -20,28 +20,28 @@ const program = new Command();
 
 program
   .name("icf")
-  .description("Incident Command Framework — CLI-first incident management backed by GitHub")
+  .description("Manage service incidents through GitHub Issues from your terminal.")
   .version(VERSION)
-  .addHelpText("beforeAll", `\n${chalk.bold.red("🚨 ICF")} — ${chalk.bold("Incident Command Framework")}\n`)
+  .addHelpText("beforeAll", `\n${chalk.bold("icf")} — Incident Command Framework\n`)
   .addHelpText("after", `
-${chalk.bold("Quick Start:")}
-  ${chalk.cyan("icf auth login")}
-  ${chalk.cyan("icf init my-org/incidents --create")}
-  ${chalk.cyan("icf incident create --title \"DB down\" --service payments --severity P0 --description \"...\"")}
-  ${chalk.cyan("icf incident list")}
-  ${chalk.cyan("icf incident resolve INC-001 --rca \"Fixed and deployed\"")}
+${chalk.bold("Quick start:")}
+  ${chalk.cyan("icf auth login")}                                              Authenticate with GitHub
+  ${chalk.cyan("icf init my-org/incidents --create")}                          Create + configure incident repo
+  ${chalk.cyan("icf incident create --severity P1 --service api --title \"...\"")}
+  ${chalk.cyan("icf incident list")}                                            List open incidents
+  ${chalk.cyan("icf incident resolve INC-001 --rca \"Fixed and deployed\"")}   Resolve with root cause
 
-${chalk.bold("Agent / pipe usage:")}
+${chalk.bold("Agent usage:")}
   ${chalk.cyan("icf incident list --json | jq '.data[] | select(.severity == \"P0\")'")}
-  ${chalk.cyan("echo '{\"title\":\"Down\",\"service\":\"api\",\"severity\":\"P1\"}' | icf incident create --input-json --json")}
-  ${chalk.cyan("ICF_JSON=1 icf incident create --input-json '{...}'")}
+  ${chalk.cyan("echo '{\"title\":\"Down\",\"service\":\"api\",\"severity\":\"P1\",\"description\":\"...\"}'")}
+  ${chalk.cyan("  | icf incident create --input-json --json")}
+  ${chalk.cyan("ICF_JSON=1 icf incident list")}                                Global JSON mode
 
-${chalk.bold("JSON mode:")}
-  All commands support ${chalk.cyan("--json")} or ${chalk.cyan("ICF_JSON=1")} env var.
-  All responses follow: ${chalk.dim("{ ok: bool, data: {}, error?: string, code?: number }")}
+${chalk.bold("JSON responses follow:")} ${chalk.dim("{ ok, data } on success — { ok: false, error, code } on failure")}
+${chalk.bold("Exit codes:")} ${chalk.dim("0 ok  1 general  2 network  3 not-found  4 auth  5 validation")}
 
-${chalk.bold("Exit Codes:")} 0=ok  1=general  2=network  3=not-found  4=auth  5=validation
-${chalk.dim("Config: ")}${getConfigPath()}
+${chalk.dim("Run")} ${chalk.cyan("icf <command> --help")} ${chalk.dim("for per-command examples.")}
+${chalk.dim("Config stored at:")} ${chalk.yellow(getConfigPath())}
 `);
 
 authCommand(program);


### PR DESCRIPTION
Closes #9, Closes #11

## Issue #11 — `icf --help` improvements

Root `icf --help` now shows:
- Clean header (no emoji), plain one-line description
- All commands with accurate descriptions
- Quick start with inline annotations
- Agent usage section with `--input-json` pipe example
- JSON response envelope documented

Each command group has a **Subcommands:** section in its `--help`.

Updated descriptions:
| Command | Before | After |
|---------|--------|-------|
| `auth` | Manage GitHub authentication | Store a GitHub token and verify it has the right scopes |
| `init` | Bootstrap a GitHub repo... | Set up a GitHub repo for ICF incident tracking (labels, templates, workflows) |
| `incident` | Manage incidents — create, list... | Open, track, and resolve service incidents |
| `config` | Manage ICF configuration | Show and validate your ICF configuration |

## Issue #9 — README humanized + agent section

`cli/README.md`:
- Plain title, no emoji in headings, sentence-case throughout
- Fixed command names: `icf incident comment` (not `timeline`), `--rca` (not `root-cause`)
- JSON examples use `.data.id` (correct shape from actual responses)
- New **Using icf as an agent** section:
  - JSON output mode + `ICF_JSON=1` env var
  - Response envelope with success/error shapes
  - Exit code table
  - `--input-json` piping with inline, stdin, and file examples
  - Full agent pipeline: create → comment → mitigate → resolve
  - Version check JSON output

Root `README.md` rewritten: plain description, repo structure, quick start, agent usage.

## Issue #10 — cloutfit/incident-reports README ✅ (pushed directly to that repo)

See: https://github.com/cloutfit/incident-reports/commit/4e0af87